### PR TITLE
[Patcher] Update gruntwork-io/terraform-aws-service-catalog/data-stores/rds

### DIFF
--- a/infrastructure-live/dev/eu-central-1/data-stores/rds/terragrunt.hcl
+++ b/infrastructure-live/dev/eu-central-1/data-stores/rds/terragrunt.hcl
@@ -1,5 +1,5 @@
 # This is the configuration for Terragrunt, a thin wrapper for Terraform: https://terragrunt.gruntwork.io/
 
 terraform {
-  source = "git::git@github.com:gruntwork-io/terraform-aws-service-catalog.git//modules/data-stores/rds?ref=v0.95.0"
+  source = "git::git@github.com:gruntwork-io/terraform-aws-service-catalog.git//modules/data-stores/rds?ref=v0.95.1"
 }


### PR DESCRIPTION

Updated the `gruntwork-io/terraform-aws-service-catalog/data-stores/rds` dependency using Patcher.

### Update summary
```yaml
successful_updates:
    - file_path: /Users/marina/go/src/github.com/gruntwork-io/patcher-action/infrastructure-live/dev/eu-central-1/data-stores/rds/terragrunt.hcl
      updated_modules:
        - repo: terraform-aws-service-catalog
          module: data-stores/rds
          previous_version: v0.95.0
          updated_version: v0.95.1
          patches_applied:
            count: 0

```
