### PR TITLE
[Patcher] Update gruntwork-io/terraform-aws-service-catalog/networking/vpc

### DIFF
--- a/infrastructure-live/dev/eu-central-1/networking/vpc/terragrunt.hcl
+++ b/infrastructure-live/dev/eu-central-1/networking/vpc/terragrunt.hcl
@@ -1,5 +1,5 @@
 # This is the configuration for Terragrunt, a thin wrapper for Terraform: https://terragrunt.gruntwork.io/
 
 terraform {
-  source = "git::git@github.com:gruntwork-io/terraform-aws-service-catalog.git//modules/networking/vpc?ref=v0.95.0"
+  source = "git::git@github.com:gruntwork-io/terraform-aws-service-catalog.git//modules/networking/vpc?ref=v0.95.1"
 }


### PR DESCRIPTION

Updated the `gruntwork-io/terraform-aws-service-catalog/networking/vpc` dependency using Patcher.

### Update summary
```yaml
successful_updates:
    - file_path: /Users/marina/go/src/github.com/gruntwork-io/patcher-action/infrastructure-live/dev/eu-central-1/networking/vpc/terragrunt.hcl
      updated_modules:
        - repo: terraform-aws-service-catalog
          module: networking/vpc
          previous_version: v0.95.0
          updated_version: v0.95.1
          patches_applied:
            count: 0

```
