### PR TITLE
Bug fix: Merge `process.env` into Patcher's env vars

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -13644,12 +13644,9 @@ function updateArgs(updateStrategy, dependency, workingDir) {
 function getPatcherEnvVars(token) {
     const telemetryId = `GHAction-${github.context.repo.owner}/${github.context.repo.repo}`;
     return {
+        ...process.env,
         "GITHUB_OAUTH_TOKEN": token,
         "PATCHER_TELEMETRY_ID": telemetryId,
-        // exec.getExecOutput does not contain a $HOME environment variable.
-        // Using a path that looks a reasonable default given the GitHub Action environment variables:
-        // https://docs.github.com/en/actions/learn-github-actions/variables.
-        "HOME": "/home"
     };
 }
 async function runPatcher(octokit, gitCommiter, binaryPath, command, { updateStrategy, dependency, workingDir, token }) {

--- a/src/action.ts
+++ b/src/action.ts
@@ -165,12 +165,9 @@ function getPatcherEnvVars(token: string): { [key: string]: string } {
   const telemetryId = `GHAction-${github.context.repo.owner}/${github.context.repo.repo}`;
 
   return {
+    ...process.env,
     "GITHUB_OAUTH_TOKEN": token,
     "PATCHER_TELEMETRY_ID": telemetryId,
-    // exec.getExecOutput does not contain a $HOME environment variable.
-    // Using a path that looks a reasonable default given the GitHub Action environment variables:
-    // https://docs.github.com/en/actions/learn-github-actions/variables.
-    "HOME": "/home"
   };
 }
 


### PR DESCRIPTION
There's a bug where the custom `$HOME` does not work in GitHub's runners, but works locally with `act`.

Merging `process.env` into the environment variable maps, it's possible to get the correct `$HOME` variable, and allow `env` be defined in the action's yaml.  