### PR TITLE
[Patcher] [infrastructure-live] Update gruntwork-io/terraform-aws-service-catalog/networking/vpc dependency

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,6 +5,9 @@ on:
     branches:
       - main
 
+env:
+  PATCHER_TELEMETRY_OPT_OUT: true
+
 jobs:
   patcher-report:
     runs-on: ubuntu-latest
@@ -17,6 +20,7 @@ jobs:
         uses: ./
         with:
           patcher_command: report
+          working_dir: infrastructure-live
 
 
   patcher-update:
@@ -32,3 +36,4 @@ jobs:
         with:
           patcher_command: update
           dependency: ${{ matrix.dependency }}
+          working_dir: infrastructure-live

--- a/dist/index.js
+++ b/dist/index.js
@@ -13554,11 +13554,11 @@ function osPlatform() {
 }
 function pullRequestBranch(dependency, workingDir) {
     let branch = "patcher-updates";
-    if (dependency) {
-        branch += `-${dependency}`;
-    }
     if (workingDir) {
         branch += `-${workingDir}`;
+    }
+    if (dependency) {
+        branch += `-${dependency}`;
     }
     return branch;
 }
@@ -13591,10 +13591,11 @@ ${patcherRawOutput}
 `;
     await exec.exec("git", ["config", "user.name", gitCommiter.name]);
     await exec.exec("git", ["config", "user.email", gitCommiter.email]);
+    await exec.exec("git", ["remote", "add", "https-origin", `https://${token}@github.com/${context.repo.owner}/${context.repo.repo}.git`]);
     await exec.exec("git", ["add", "."]);
     await exec.exec("git", ["checkout", "-b", head]);
     await exec.exec("git", ["commit", "-m", commitMessage]);
-    await exec.exec("git", ["push", "-f", `https://${token}@github.com/${context.repo.owner}/${context.repo.repo}.git`]);
+    await exec.exec("git", ["push", "--force", "https-origin", `${head}:refs/heads/${head}`]);
     const repoDetails = await octokit.rest.repos.get({ ...context.repo });
     const base = repoDetails.data.default_branch;
     core.debug(`Base branch is ${base}. Opening the PR against it.`);

--- a/infrastructure-live/dev/eu-central-1/networking/vpc/terragrunt.hcl
+++ b/infrastructure-live/dev/eu-central-1/networking/vpc/terragrunt.hcl
@@ -1,5 +1,5 @@
 # This is the configuration for Terragrunt, a thin wrapper for Terraform: https://terragrunt.gruntwork.io/
 
 terraform {
-  source = "git::git@github.com:gruntwork-io/terraform-aws-service-catalog.git//modules/networking/vpc?ref=v0.95.0"
+  source = "git::git@github.com:gruntwork-io/terraform-aws-service-catalog.git//modules/networking/vpc?ref=v0.95.1"
 }

--- a/src/action.ts
+++ b/src/action.ts
@@ -49,12 +49,12 @@ function osPlatform() {
 function pullRequestBranch(dependency: string, workingDir: string): string {
   let branch = "patcher-updates"
 
-  if (dependency) {
-    branch += `-${dependency}`
-  }
-
   if (workingDir) {
     branch += `-${workingDir}`
+  }
+
+  if (dependency) {
+    branch += `-${dependency}`
   }
 
   return branch;
@@ -94,11 +94,13 @@ ${patcherRawOutput}
 
   await exec.exec("git", ["config", "user.name", gitCommiter.name])
   await exec.exec("git", ["config", "user.email", gitCommiter.email])
+  await exec.exec("git", ["remote", "add", "https-origin", `https://${token}@github.com/${context.repo.owner}/${context.repo.repo}.git`])
+
   await exec.exec("git", ["add", "."])
   await exec.exec("git", ["checkout", "-b", head])
   await exec.exec("git", ["commit", "-m", commitMessage])
 
-  await exec.exec("git", ["push", "-f", `https://${token}@github.com/${context.repo.owner}/${context.repo.repo}.git`])
+  await exec.exec("git", ["push", "--force", "https-origin", `${head}:refs/heads/${head}`])
 
   const repoDetails = await octokit.rest.repos.get({...context.repo});
   const base = repoDetails.data.default_branch;


### PR DESCRIPTION

Updated the `gruntwork-io/terraform-aws-service-catalog/networking/vpc` dependency using Patcher.

### Update summary
```yaml
successful_updates:
    - file_path: /Users/marina/go/src/github.com/gruntwork-io/patcher-action/infrastructure-live/dev/eu-central-1/networking/vpc/terragrunt.hcl
      updated_modules:
        - repo: terraform-aws-service-catalog
          module: networking/vpc
          previous_version: v0.95.0
          updated_version: v0.95.1
          patches_applied:
            count: 0

```
