### PR TITLE
[Patcher] [infrastructure-live] Update gruntwork-io/terraform-aws-service-catalog/data-stores/rds dependency

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,6 +5,9 @@ on:
     branches:
       - main
 
+env:
+  PATCHER_TELEMETRY_OPT_OUT: true
+
 jobs:
   patcher-report:
     runs-on: ubuntu-latest
@@ -17,6 +20,7 @@ jobs:
         uses: ./
         with:
           patcher_command: report
+          working_dir: infrastructure-live
 
 
   patcher-update:
@@ -32,3 +36,4 @@ jobs:
         with:
           patcher_command: update
           dependency: ${{ matrix.dependency }}
+          working_dir: infrastructure-live

--- a/dist/index.js
+++ b/dist/index.js
@@ -13554,11 +13554,11 @@ function osPlatform() {
 }
 function pullRequestBranch(dependency, workingDir) {
     let branch = "patcher-updates";
-    if (dependency) {
-        branch += `-${dependency}`;
-    }
     if (workingDir) {
         branch += `-${workingDir}`;
+    }
+    if (dependency) {
+        branch += `-${dependency}`;
     }
     return branch;
 }
@@ -13594,7 +13594,9 @@ ${patcherRawOutput}
     await exec.exec("git", ["add", "."]);
     await exec.exec("git", ["checkout", "-b", head]);
     await exec.exec("git", ["commit", "-m", commitMessage]);
-    await exec.exec("git", ["push", "-f", `https://${token}@github.com/${context.repo.owner}/${context.repo.repo}.git`]);
+    // await exec.exec("git", ["push", "--force-with-lease", ])
+    await exec.exec("git", ["remote", "add", "https-origin", `https://${token}@github.com/${context.repo.owner}/${context.repo.repo}.git`]);
+    await exec.exec("git", ["push", "-u", "https-origin", head]);
     const repoDetails = await octokit.rest.repos.get({ ...context.repo });
     const base = repoDetails.data.default_branch;
     core.debug(`Base branch is ${base}. Opening the PR against it.`);

--- a/infrastructure-live/dev/eu-central-1/data-stores/rds/terragrunt.hcl
+++ b/infrastructure-live/dev/eu-central-1/data-stores/rds/terragrunt.hcl
@@ -1,5 +1,5 @@
 # This is the configuration for Terragrunt, a thin wrapper for Terraform: https://terragrunt.gruntwork.io/
 
 terraform {
-  source = "git::git@github.com:gruntwork-io/terraform-aws-service-catalog.git//modules/data-stores/rds?ref=v0.95.0"
+  source = "git::git@github.com:gruntwork-io/terraform-aws-service-catalog.git//modules/data-stores/rds?ref=v0.95.1"
 }

--- a/src/action.ts
+++ b/src/action.ts
@@ -49,12 +49,12 @@ function osPlatform() {
 function pullRequestBranch(dependency: string, workingDir: string): string {
   let branch = "patcher-updates"
 
-  if (dependency) {
-    branch += `-${dependency}`
-  }
-
   if (workingDir) {
     branch += `-${workingDir}`
+  }
+
+  if (dependency) {
+    branch += `-${dependency}`
   }
 
   return branch;
@@ -98,7 +98,9 @@ ${patcherRawOutput}
   await exec.exec("git", ["checkout", "-b", head])
   await exec.exec("git", ["commit", "-m", commitMessage])
 
-  await exec.exec("git", ["push", "-f", `https://${token}@github.com/${context.repo.owner}/${context.repo.repo}.git`])
+  // await exec.exec("git", ["push", "--force-with-lease", ])
+  await exec.exec("git", ["remote", "add", "https-origin", `https://${token}@github.com/${context.repo.owner}/${context.repo.repo}.git`])
+  await exec.exec("git", ["push", "-u", "https-origin", head])
 
   const repoDetails = await octokit.rest.repos.get({...context.repo});
   const base = repoDetails.data.default_branch;


### PR DESCRIPTION

Updated the `gruntwork-io/terraform-aws-service-catalog/data-stores/rds` dependency using Patcher.

### Update summary
```yaml
successful_updates:
    - file_path: /Users/marina/go/src/github.com/gruntwork-io/patcher-action/infrastructure-live/dev/eu-central-1/data-stores/rds/terragrunt.hcl
      updated_modules:
        - repo: terraform-aws-service-catalog
          module: data-stores/rds
          previous_version: v0.95.0
          updated_version: v0.95.1
          patches_applied:
            count: 0

```
