### PR TITLE
Fix undefined error on `count` + extract .tar.gz dependencies in the `/tmp` folder

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -13596,11 +13596,17 @@ function pullRequestReleaseNotesBreakingVersion(nextBreakingVersion) {
     }
     return "";
 }
+function pullRequestPatchesApplied(patchesApplied) {
+    if (patchesApplied) {
+        return `- Patches applied: ${patchesApplied.count}`;
+    }
+    return "";
+}
 function pullRequestBodyUpdatedModules(modules) {
     return modules
         .map((module) => `  - Previous version: \`${module.previous_version}\`
   - Updated version: \`${module.updated_version}\` ${pullRequestReleaseNotesBreakingVersion(module.next_breaking_version)}
-  - Patches applied: ${module.patches_applied.count}`)
+  ${pullRequestPatchesApplied(module.patches_applied)}`)
         .join("\n");
 }
 function pullRequestBodySuccessfulUpdates(updatedModules) {

--- a/dist/index.js
+++ b/dist/index.js
@@ -13746,9 +13746,9 @@ async function downloadGitHubBinary(octokit, owner, repo, tag, token) {
     });
     core.debug(`${owner}/${repo}@'${tag}' has been downloaded at ${downloadedPath}`);
     if (path.extname(asset.name) === ".gz") {
-        await exec.exec(`mkdir ${binaryName}`);
-        await exec.exec(`tar -C ${binaryName} -xzvf ${downloadedPath}`);
-        const extractedPath = path.join(binaryName, binaryName);
+        await exec.exec(`mkdir /tmp/${binaryName}`);
+        await exec.exec(`tar -C /tmp/${binaryName} -xzvf ${downloadedPath}`);
+        const extractedPath = path.join("/tmp", binaryName, binaryName);
         const cachedPath = await toolCache.cacheFile(extractedPath, binaryName, repo, tag);
         core.debug(`Cached in ${cachedPath}`);
         return { folder: cachedPath, name: binaryName };

--- a/src/action.ts
+++ b/src/action.ts
@@ -366,10 +366,10 @@ async function downloadGitHubBinary(
   );
 
   if (path.extname(asset.name) === ".gz") {
-    await exec.exec(`mkdir ${binaryName}`);
-    await exec.exec(`tar -C ${binaryName} -xzvf ${downloadedPath}`);
+    await exec.exec(`mkdir /tmp/${binaryName}`);
+    await exec.exec(`tar -C /tmp/${binaryName} -xzvf ${downloadedPath}`);
 
-    const extractedPath = path.join(binaryName, binaryName);
+    const extractedPath = path.join("/tmp", binaryName, binaryName);
 
     const cachedPath = await toolCache.cacheFile(
       extractedPath,

--- a/src/action.ts
+++ b/src/action.ts
@@ -143,6 +143,14 @@ function pullRequestReleaseNotesBreakingVersion(
   return "";
 }
 
+function pullRequestPatchesApplied(patchesApplied: PatchesApplied): string {
+  if (patchesApplied) {
+    return `- Patches applied: ${patchesApplied.count}`;
+  }
+
+  return "";
+}
+
 function pullRequestBodyUpdatedModules(modules: UpdatedModule[]): string {
   return modules
     .map(
@@ -150,7 +158,7 @@ function pullRequestBodyUpdatedModules(modules: UpdatedModule[]): string {
   - Updated version: \`${
     module.updated_version
   }\` ${pullRequestReleaseNotesBreakingVersion(module.next_breaking_version)}
-  - Patches applied: ${module.patches_applied.count}`,
+  ${pullRequestPatchesApplied(module.patches_applied)}`,
     )
     .join("\n");
 }

--- a/tests/action.test.ts
+++ b/tests/action.test.ts
@@ -23,48 +23,48 @@ manual_steps_you_must_follow:
       "gruntwork-io/terraform-aws-service-catalog/networking/vpc",
     );
     expect(result).toMatchInlineSnapshot(`
-":robot: This is an automated pull request opened by [Patcher](https://docs.gruntwork.io/patcher/).
+      ":robot: This is an automated pull request opened by [Patcher](https://docs.gruntwork.io/patcher/).
 
-## Description
+      ## Description
 
-Updated the \`gruntwork-io/terraform-aws-service-catalog/networking/vpc\` dependency.
+      Updated the \`gruntwork-io/terraform-aws-service-catalog/networking/vpc\` dependency.
 
-### Updated files
+      ### Updated files
 
-- \`dev/eu-central-1/networking/vpc/terragrunt.hcl\`
-  - Previous version: \`v0.95.0\`
-  - Updated version: \`v0.96.0\` ([Release notes for v0.96.0](https://github.com/gruntwork-io/terraform-aws-service-catalog/releases/tag/v0.96.0))
-  - Patches applied: 0
+      - \`dev/eu-central-1/networking/vpc/terragrunt.hcl\`
+        - Previous version: \`v0.95.0\`
+        - Updated version: \`v0.96.0\` ([Release notes for v0.96.0](https://github.com/gruntwork-io/terraform-aws-service-catalog/releases/tag/v0.96.0))
+        - Patches applied: 0
 
-<details>
-  <summary>Raw output from \`patcher update\`</summary>
+      <details>
+        <summary>Raw output from \`patcher update\`</summary>
 
-  \`\`\`yaml
-successful_updates:
-   - file_path: dev/eu-central-1/networking/vpc/terragrunt.hcl
-     updated_modules:
-       - repo: terraform-aws-service-catalog
-         module: networking/vpc
-         previous_version: v0.95.0
-         updated_version: v0.96.0
-         next_breaking_version:
-           version: v0.96.0
-           release_notes_url: https://github.com/gruntwork-io/terraform-aws-service-catalog/releases/tag/v0.96.0
-         patches_applied:
-           count: 0
-manual_steps_you_must_follow:
-   - instructions_file_path: dev/eu-central-1/networking/vpc/README-TO-COMPLETE-UPDATE.md
-  \`\`\`
+        \`\`\`yaml
+      successful_updates:
+         - file_path: dev/eu-central-1/networking/vpc/terragrunt.hcl
+           updated_modules:
+             - repo: terraform-aws-service-catalog
+               module: networking/vpc
+               previous_version: v0.95.0
+               updated_version: v0.96.0
+               next_breaking_version:
+                 version: v0.96.0
+                 release_notes_url: https://github.com/gruntwork-io/terraform-aws-service-catalog/releases/tag/v0.96.0
+               patches_applied:
+                 count: 0
+      manual_steps_you_must_follow:
+         - instructions_file_path: dev/eu-central-1/networking/vpc/README-TO-COMPLETE-UPDATE.md
+        \`\`\`
 
-</details>
+      </details>
 
-## Steps to review
+      ## Steps to review
 
-1. Check the proposed changes to the \`terraform\` and/or \`terragrunt\` configuration files.
-1. Follow the instructions outlined in the \`README-TO-COMPLETE-UPDATE.md\` file and delete it once the update is complete.
-1. Validate the changes in the infrastructure by running \`terraform/terragrunt plan\`.
-1. Upon approval, proceed with deploying the infrastructure changes."
-`);
+      1. Check the proposed changes to the \`terraform\` and/or \`terragrunt\` configuration files.
+      1. Follow the instructions outlined in the \`README-TO-COMPLETE-UPDATE.md\` file and delete it once the update is complete.
+      1. Validate the changes in the infrastructure by running \`terraform/terragrunt plan\`.
+      1. Upon approval, proceed with deploying the infrastructure changes."
+    `);
   });
   test("parses patcher's output when updating two files", () => {
     const patcherRawOutput = `successful_updates:
@@ -95,60 +95,60 @@ manual_steps_you_must_follow:
       "gruntwork-io/terraform-aws-service-catalog/services/k8s-service",
     );
     expect(result).toMatchInlineSnapshot(`
-":robot: This is an automated pull request opened by [Patcher](https://docs.gruntwork.io/patcher/).
+      ":robot: This is an automated pull request opened by [Patcher](https://docs.gruntwork.io/patcher/).
 
-## Description
+      ## Description
 
-Updated the \`gruntwork-io/terraform-aws-service-catalog/services/k8s-service\` dependency.
+      Updated the \`gruntwork-io/terraform-aws-service-catalog/services/k8s-service\` dependency.
 
-### Updated files
+      ### Updated files
 
-- \`dev/us-east-1/dev/services/gruntwork-website-preview-environments/pr-554/terragrunt.hcl\`
-  - Previous version: \`v0.102.7\`
-  - Updated version: \`v0.103.0\` ([Release notes for v0.103.0](https://github.com/gruntwork-io/terraform-aws-service-catalog/releases/tag/v0.103.0))
-  - Patches applied: 0
-- \`dev/us-east-1/dev/services/gruntwork-website-preview-environments/pr-560/terragrunt.hcl\`
-  - Previous version: \`v0.102.7\`
-  - Updated version: \`v0.103.0\` ([Release notes for v0.103.0](https://github.com/gruntwork-io/terraform-aws-service-catalog/releases/tag/v0.103.0))
-  - Patches applied: 0
+      - \`dev/us-east-1/dev/services/gruntwork-website-preview-environments/pr-554/terragrunt.hcl\`
+        - Previous version: \`v0.102.7\`
+        - Updated version: \`v0.103.0\` ([Release notes for v0.103.0](https://github.com/gruntwork-io/terraform-aws-service-catalog/releases/tag/v0.103.0))
+        - Patches applied: 0
+      - \`dev/us-east-1/dev/services/gruntwork-website-preview-environments/pr-560/terragrunt.hcl\`
+        - Previous version: \`v0.102.7\`
+        - Updated version: \`v0.103.0\` ([Release notes for v0.103.0](https://github.com/gruntwork-io/terraform-aws-service-catalog/releases/tag/v0.103.0))
+        - Patches applied: 0
 
-<details>
-  <summary>Raw output from \`patcher update\`</summary>
+      <details>
+        <summary>Raw output from \`patcher update\`</summary>
 
-  \`\`\`yaml
-successful_updates:
-  - file_path: dev/us-east-1/dev/services/gruntwork-website-preview-environments/pr-554/terragrunt.hcl
-    updated_modules:
-      - repo: terraform-aws-service-catalog
-        module: services/k8s-service
-        previous_version: v0.102.7
-        updated_version: v0.103.0
-        next_breaking_version:
-          version: v0.103.0
-          release_notes_url: https://github.com/gruntwork-io/terraform-aws-service-catalog/releases/tag/v0.103.0
-        patches_applied:
-          count: 0
-  - file_path: dev/us-east-1/dev/services/gruntwork-website-preview-environments/pr-560/terragrunt.hcl
-    updated_modules:
-      - repo: terraform-aws-service-catalog
-        module: services/k8s-service
-        previous_version: v0.102.7
-        updated_version: v0.103.0
-        next_breaking_version:
-          version: v0.103.0
-          release_notes_url: https://github.com/gruntwork-io/terraform-aws-service-catalog/releases/tag/v0.103.0
-        patches_applied:
-          count: 0
-  \`\`\`
+        \`\`\`yaml
+      successful_updates:
+        - file_path: dev/us-east-1/dev/services/gruntwork-website-preview-environments/pr-554/terragrunt.hcl
+          updated_modules:
+            - repo: terraform-aws-service-catalog
+              module: services/k8s-service
+              previous_version: v0.102.7
+              updated_version: v0.103.0
+              next_breaking_version:
+                version: v0.103.0
+                release_notes_url: https://github.com/gruntwork-io/terraform-aws-service-catalog/releases/tag/v0.103.0
+              patches_applied:
+                count: 0
+        - file_path: dev/us-east-1/dev/services/gruntwork-website-preview-environments/pr-560/terragrunt.hcl
+          updated_modules:
+            - repo: terraform-aws-service-catalog
+              module: services/k8s-service
+              previous_version: v0.102.7
+              updated_version: v0.103.0
+              next_breaking_version:
+                version: v0.103.0
+                release_notes_url: https://github.com/gruntwork-io/terraform-aws-service-catalog/releases/tag/v0.103.0
+              patches_applied:
+                count: 0
+        \`\`\`
 
-</details>
+      </details>
 
-## Steps to review
+      ## Steps to review
 
-1. Check the proposed changes to the \`terraform\` and/or \`terragrunt\` configuration files.
-1. Validate the changes in the infrastructure by running \`terraform/terragrunt plan\`.
-1. Upon approval, proceed with deploying the infrastructure changes."
-`);
+      1. Check the proposed changes to the \`terraform\` and/or \`terragrunt\` configuration files.
+      1. Validate the changes in the infrastructure by running \`terraform/terragrunt plan\`.
+      1. Upon approval, proceed with deploying the infrastructure changes."
+    `);
   });
   test("parses patcher's output when updating two files", () => {
     const patcherRawOutput = `  successful_updates:
@@ -165,41 +165,89 @@ successful_updates:
       "gruntwork-io/terraform-aws-utilities/request-quota-increase",
     );
     expect(result).toMatchInlineSnapshot(`
-":robot: This is an automated pull request opened by [Patcher](https://docs.gruntwork.io/patcher/).
+      ":robot: This is an automated pull request opened by [Patcher](https://docs.gruntwork.io/patcher/).
 
-## Description
+      ## Description
 
-Updated the \`gruntwork-io/terraform-aws-utilities/request-quota-increase\` dependency.
+      Updated the \`gruntwork-io/terraform-aws-utilities/request-quota-increase\` dependency.
 
-### Updated files
+      ### Updated files
 
-- \`dev/us-east-1/_regional/service-quotas/terragrunt.hcl\`
-  - Previous version: \`v0.9.2\`
-  - Updated version: \`v0.9.4\` 
-  - Patches applied: 0
+      - \`dev/us-east-1/_regional/service-quotas/terragrunt.hcl\`
+        - Previous version: \`v0.9.2\`
+        - Updated version: \`v0.9.4\` 
+        - Patches applied: 0
 
-<details>
-  <summary>Raw output from \`patcher update\`</summary>
+      <details>
+        <summary>Raw output from \`patcher update\`</summary>
 
-  \`\`\`yaml
-  successful_updates:
-      - file_path: dev/us-east-1/_regional/service-quotas/terragrunt.hcl
+        \`\`\`yaml
+        successful_updates:
+            - file_path: dev/us-east-1/_regional/service-quotas/terragrunt.hcl
+              updated_modules:
+                - repo: terraform-aws-utilities
+                  module: request-quota-increase
+                  previous_version: v0.9.2
+                  updated_version: v0.9.4
+                  patches_applied:
+                    count: 0
+        \`\`\`
+
+      </details>
+
+      ## Steps to review
+
+      1. Check the proposed changes to the \`terraform\` and/or \`terragrunt\` configuration files.
+      1. Validate the changes in the infrastructure by running \`terraform/terragrunt plan\`.
+      1. Upon approval, proceed with deploying the infrastructure changes."
+    `);
+  });
+  test("parses patcher's output when the module is up-to-date", () => {
+    const patcherRawOutput = `  successful_updates:
+      - file_path: services/gruntwork-website-ci-deployer/main.tf
         updated_modules:
-          - repo: terraform-aws-utilities
-            module: request-quota-increase
-            previous_version: v0.9.2
-            updated_version: v0.9.4
-            patches_applied:
-              count: 0
-  \`\`\`
+          - repo: terraform-kubernetes-helm
+            module: k8s-service-account
+            previous_version: v0.6.2
+            updated_version: v0.6.2`;
+    const result = pullRequestBody(
+      patcherRawOutput,
+      "gruntwork-io/terraform-kubernetes-help/k8s-service-account",
+    );
+    expect(result).toMatchInlineSnapshot(`
+      ":robot: This is an automated pull request opened by [Patcher](https://docs.gruntwork.io/patcher/).
 
-</details>
+      ## Description
 
-## Steps to review
+      Updated the \`gruntwork-io/terraform-kubernetes-help/k8s-service-account\` dependency.
 
-1. Check the proposed changes to the \`terraform\` and/or \`terragrunt\` configuration files.
-1. Validate the changes in the infrastructure by running \`terraform/terragrunt plan\`.
-1. Upon approval, proceed with deploying the infrastructure changes."
-`);
+      ### Updated files
+
+      - \`services/gruntwork-website-ci-deployer/main.tf\`
+        - Previous version: \`v0.6.2\`
+        - Updated version: \`v0.6.2\` 
+        
+
+      <details>
+        <summary>Raw output from \`patcher update\`</summary>
+
+        \`\`\`yaml
+        successful_updates:
+            - file_path: services/gruntwork-website-ci-deployer/main.tf
+              updated_modules:
+                - repo: terraform-kubernetes-helm
+                  module: k8s-service-account
+                  previous_version: v0.6.2
+                  updated_version: v0.6.2
+        \`\`\`
+
+      </details>
+
+      ## Steps to review
+
+      1. Check the proposed changes to the \`terraform\` and/or \`terragrunt\` configuration files.
+      1. Validate the changes in the infrastructure by running \`terraform/terragrunt plan\`.
+      1. Upon approval, proceed with deploying the infrastructure changes."
+    `);
   });
 });


### PR DESCRIPTION
[Jira: PATCHER-320](https://gruntwork.atlassian.net/browse/PATCHER-320)

- Some actions are failing with `Action failed with "TypeError: Cannot read properties of undefined (reading 'count')"`. This happened because `patches_applied` is not returned every time.
- When extracting the dependencies on `tar.gz`dependencies, they were going to the current folder, which is the project's folder, causing them to be commited also. Now they will be extracted in a `tmp` folder.