### PR TITLE
Bump Patcher CLI to v0.5.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,3 +38,18 @@ steps:
 
 Refer to the [Promotion Workflows with Terraform](https://blog.gruntwork.io/promotion-workflows-with-terraform-13c05bed953d).
 
+## Developer Setup
+
+If you need to make changes to the action, you can build it locally with the following commands:
+
+```sh
+# install dependencies
+yarn
+
+# run the tests
+yarn test
+
+# build a release
+yarn build
+```
+

--- a/dist/index.js
+++ b/dist/index.js
@@ -13536,7 +13536,7 @@ const exec = __importStar(__nccwpck_require__(1514));
 // Define constants
 const GRUNTWORK_GITHUB_ORG = "gruntwork-io";
 const PATCHER_GITHUB_REPO = "patcher-cli";
-const PATCHER_VERSION = "v0.4.3";
+const PATCHER_VERSION = "v0.5.1";
 const TERRAPATCH_GITHUB_REPO = "terrapatch-cli";
 const TERRAPATCH_VERSION = "v0.1.3";
 const HCLEDIT_ORG = "minamijoyo";

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "patcher-action",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Run Patcher by Gruntwork.io",
   "main": "index.js",
   "repository": "git@github.com:gruntwork-io/patcher-action.git",

--- a/src/action.ts
+++ b/src/action.ts
@@ -12,7 +12,7 @@ import { Api as GitHub } from "@octokit/plugin-rest-endpoint-methods/dist-types/
 
 const GRUNTWORK_GITHUB_ORG = "gruntwork-io";
 const PATCHER_GITHUB_REPO = "patcher-cli";
-const PATCHER_VERSION = "v0.4.3";
+const PATCHER_VERSION = "v0.5.1";
 const TERRAPATCH_GITHUB_REPO = "terrapatch-cli";
 const TERRAPATCH_VERSION = "v0.1.3";
 


### PR DESCRIPTION
This PR bumps the Patcher CLI to `v0.5.1`. It also includes some developer documentation for those new to the project.