### PR TITLE
Bump Docs and Example Dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ It will run `patcher update` in the whole repo, and open a Pull Request with the
 
 ```yaml
 steps:
-  - uses: actions/checkout@v3
+  - uses: actions/checkout@v4
   - uses: gruntwork-io/patcher-action
 ```
 

--- a/examples/github/workflows/patcher.yml
+++ b/examples/github/workflows/patcher.yml
@@ -9,11 +9,11 @@ jobs:
     name: Check for README-TO-COMPLETE-UPDATE.md files
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      
+      - uses: actions/checkout@v4
+
       - name: Check file existence
         id: check_files
-        uses: andstor/file-existence-action@v1
+        uses: andstor/file-existence-action@v3
         with:
           files: "**/README-TO-COMPLETE-UPDATE.md"
 

--- a/examples/github/workflows/update-dev.yml
+++ b/examples/github/workflows/update-dev.yml
@@ -5,7 +5,7 @@ on:
     types: [new_module_release]
   schedule:
     # 04:15 UTC on Mondays
-    - cron: '15 4 * * 1'
+    - cron: "15 4 * * 1"
   pull_request_target:
     types:
       - closed
@@ -23,8 +23,9 @@ jobs:
     if: github.event.pull_request.merged == true && contains(github.event.pull_request.labels.*.name, 'updates-dev')
     runs-on: ubuntu-latest
     steps:
-      - uses: peter-evans/repository-dispatch@v2
+      - uses: peter-evans/repository-dispatch@v3
         with:
+          token: ${{ secrets.GITHUB_TOKEN }}
           repository: ${{ github.repository }}
           event-type: dev_updates_merged
           client-payload: '{"ref": "${{ github.ref }}", "sha": "${{ github.sha }}", "branch": "${{ github.head_ref }}" }'
@@ -33,7 +34,7 @@ jobs:
     if: github.event_name == 'repository_dispatch' || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Create trigger source message
         if: github.event_name == 'repository_dispatch'
         id: trigger_event

--- a/examples/github/workflows/update-prod.yml
+++ b/examples/github/workflows/update-prod.yml
@@ -16,7 +16,7 @@ jobs:
     if: github.event_name == 'repository_dispatch' || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: gruntwork-io/patcher-action@v1
         with:
           working_dir: ${{ env.ENV_FOLDER_NAME }}

--- a/examples/github/workflows/update-stage.yml
+++ b/examples/github/workflows/update-stage.yml
@@ -21,7 +21,7 @@ jobs:
     if: github.event.pull_request.merged == true && contains(github.event.pull_request.labels.*.name, 'updates-stage')
     runs-on: ubuntu-latest
     steps:
-      - uses: peter-evans/repository-dispatch@v2
+      - uses: peter-evans/repository-dispatch@v3
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           repository: ${{ github.repository }}
@@ -32,7 +32,7 @@ jobs:
     if: github.event_name == 'repository_dispatch'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: gruntwork-io/patcher-action@v1
         with:
           working_dir: ${{ env.ENV_FOLDER_NAME }}


### PR DESCRIPTION
This PR updates the included docs and examples to use the new versions of various GitHub Actions dependencies. We previously updated our code to use these new versions but didn't update them.

The way we use these dependencies are backwards compatible with the former versions so they are safe to bump!