### PR TITLE
add ability to use a read PAT for report and update, separately from publish PAT

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -11,11 +11,9 @@ inputs:
     description: "GitHub's Personal Access Token (PAT)."
     default: ${{ github.token }}
   read_token:
-    description: "Personal Access Token (PAT) used for 'report' and 'update' to ingest dependencies and their updated versions."
-    default: ${{ github.token }}
+    description: "Personal Access Token (PAT) used for 'report' and 'update' to ingest dependencies and their updated versions. If left unset, github_token will be used."
   update_token:
-    description: "Personal Access Token (PAT) used for 'update' to publish PRs against the relevant repo."
-    default: ${{ github.token }}
+    description: "Personal Access Token (PAT) used for 'update' to publish PRs against the relevant repo. If left unset, github_token will be used."
   patcher_command:
     description: "Patcher command to run. Valid options: 'update' or 'report'."
     default: "update"

--- a/action.yml
+++ b/action.yml
@@ -8,7 +8,10 @@ branding:
 
 inputs:
   github_token:
-    description: "GitHub's Personal Access Token (PAT). Defaults to GITHUB_TOKEN."
+    description: "GitHub's Personal Access Token (PAT)."
+    default: ${{ github.token }}
+  read_token:
+    description: "Personal Access Token (PAT) used for 'report' and 'update' to ingest dependencies and their updated versions."
     default: ${{ github.token }}
   update_token:
     description: "Personal Access Token (PAT) used for 'update' to publish PRs against the relevant repo."

--- a/action.yml
+++ b/action.yml
@@ -8,7 +8,7 @@ branding:
 
 inputs:
   github_token:
-    description: "GitHub's Personal Access Token (PAT)."
+    description: "GitHub's Personal Access Token (PAT). Used to authenticate usage of Patcher as an action."
     default: ${{ github.token }}
   read_token:
     description: "Personal Access Token (PAT) used for 'report' and 'update' to ingest dependencies and their updated versions. If left unset, github_token will be used."

--- a/dist/index.js
+++ b/dist/index.js
@@ -13535,7 +13535,7 @@ const exec = __importStar(__nccwpck_require__(1514));
 // Define constants
 const GRUNTWORK_GITHUB_ORG = "gruntwork-io";
 const PATCHER_GITHUB_REPO = "patcher-cli";
-const PATCHER_VERSION = "v0.9.5";
+const PATCHER_VERSION = "v0.10.0";
 const TERRAPATCH_GITHUB_REPO = "terrapatch-cli";
 const TERRAPATCH_VERSION = "v0.1.6";
 const HCLEDIT_ORG = "minamijoyo";
@@ -13693,22 +13693,23 @@ function updateArgs(specFile, updateStrategy, prBranch, prTitle, dependency, wor
     }
     return args.concat([workingDir]);
 }
-function getPatcherEnvVars(gitCommiter, token) {
+function getPatcherEnvVars(gitCommiter, readToken, updateToken) {
     const telemetryId = `GHAction-${github.context.repo.owner}/${github.context.repo.repo}`;
     return {
         ...process.env,
-        GITHUB_OAUTH_TOKEN: token,
+        GITHUB_OAUTH_TOKEN: readToken,
+        GITHUB_PUBLISH_TOKEN: updateToken,
         PATCHER_TELEMETRY_ID: telemetryId,
         GIT_AUTHOR_NAME: gitCommiter.name,
         GIT_AUTHOR_EMAIL: gitCommiter.email,
     };
 }
-async function runPatcher(gitCommiter, command, { specFile, includeDirs, excludeDirs, updateStrategy, prBranch, prTitle, dependency, workingDir, updateToken, dryRun, noColor, }) {
+async function runPatcher(gitCommiter, command, { specFile, includeDirs, excludeDirs, updateStrategy, prBranch, prTitle, dependency, workingDir, readToken, updateToken, dryRun, noColor, }) {
     switch (command) {
         case REPORT_COMMAND: {
             core.startGroup("Running 'patcher report'");
             const reportOutput = await exec.getExecOutput("patcher", reportArgs(specFile, includeDirs, excludeDirs, workingDir, noColor), {
-                env: getPatcherEnvVars(gitCommiter, updateToken),
+                env: getPatcherEnvVars(gitCommiter, readToken, updateToken),
             });
             core.endGroup();
             core.startGroup("Setting upgrade spec output");
@@ -13729,7 +13730,7 @@ async function runPatcher(gitCommiter, command, { specFile, includeDirs, exclude
             }
             core.startGroup(groupName);
             const updateOutput = await exec.getExecOutput("patcher", updateArgs(specFile, updateStrategy, prBranch, prTitle, dependency, workingDir, dryRun, noColor), {
-                env: getPatcherEnvVars(gitCommiter, updateToken),
+                env: getPatcherEnvVars(gitCommiter, readToken, updateToken),
             });
             core.endGroup();
             core.startGroup("Setting 'updateResult' output");
@@ -13769,6 +13770,7 @@ async function validateAccessToPatcherCli(octokit) {
 }
 async function run() {
     const gruntworkToken = core.getInput("github_token");
+    const patcherReadToken = core.getInput("read_token");
     const patcherUpdateToken = core.getInput("update_token");
     const command = core.getInput("patcher_command");
     const updateStrategy = core.getInput("update_strategy");
@@ -13785,9 +13787,11 @@ async function run() {
     // if the user didn't specify a token specifically for `patcher update`,
     // that's ok, we can try to use the github token instead. doing this adoption
     // is for back compatibility reasons
+    const readToken = patcherReadToken ? patcherReadToken : gruntworkToken;
     const updateToken = patcherUpdateToken ? patcherUpdateToken : gruntworkToken;
     // Always mask the token strings in the logs.
     core.setSecret(gruntworkToken);
+    core.setSecret(readToken);
     core.setSecret(updateToken);
     // Only run the action if the user has access to Patcher. Otherwise, the download won't work.
     const octokit = github.getOctokit(gruntworkToken);
@@ -13811,6 +13815,7 @@ async function run() {
         prTitle,
         dependency,
         workingDir,
+        readToken,
         updateToken,
         dryRun,
         noColor,

--- a/src/action.ts
+++ b/src/action.ts
@@ -266,7 +266,11 @@ function updateArgs(
   return args.concat([workingDir]);
 }
 
-function getPatcherEnvVars(gitCommiter: GitCommitter, readToken: string, updateToken: string): { [key: string]: string } {
+function getPatcherEnvVars(
+  gitCommiter: GitCommitter,
+  readToken: string,
+  updateToken: string
+): { [key: string]: string } {
   const telemetryId = `GHAction-${github.context.repo.owner}/${github.context.repo.repo}`;
 
   return {

--- a/src/action.ts
+++ b/src/action.ts
@@ -11,7 +11,7 @@ import { Api as GitHub } from "@octokit/plugin-rest-endpoint-methods/dist-types/
 
 const GRUNTWORK_GITHUB_ORG = "gruntwork-io";
 const PATCHER_GITHUB_REPO = "patcher-cli";
-const PATCHER_VERSION = "v0.9.5";
+const PATCHER_VERSION = "v0.10.0";
 const TERRAPATCH_GITHUB_REPO = "terrapatch-cli";
 const TERRAPATCH_VERSION = "v0.1.6";
 
@@ -52,6 +52,7 @@ type PatcherCliArgs = {
   prTitle: string;
   dependency: string;
   workingDir: string;
+  readToken: string;
   updateToken: string;
   dryRun: boolean;
   noColor: boolean;
@@ -265,12 +266,13 @@ function updateArgs(
   return args.concat([workingDir]);
 }
 
-function getPatcherEnvVars(gitCommiter: GitCommitter, token: string): { [key: string]: string } {
+function getPatcherEnvVars(gitCommiter: GitCommitter, readToken: string, updateToken: string): { [key: string]: string } {
   const telemetryId = `GHAction-${github.context.repo.owner}/${github.context.repo.repo}`;
 
   return {
     ...process.env,
-    GITHUB_OAUTH_TOKEN: token,
+    GITHUB_OAUTH_TOKEN: readToken,
+    GITHUB_PUBLISH_TOKEN: updateToken,
     PATCHER_TELEMETRY_ID: telemetryId,
     GIT_AUTHOR_NAME: gitCommiter.name,
     GIT_AUTHOR_EMAIL: gitCommiter.email,
@@ -289,6 +291,7 @@ async function runPatcher(
     prTitle,
     dependency,
     workingDir,
+    readToken,
     updateToken,
     dryRun,
     noColor,
@@ -301,7 +304,7 @@ async function runPatcher(
         "patcher",
         reportArgs(specFile, includeDirs, excludeDirs, workingDir, noColor),
         {
-          env: getPatcherEnvVars(gitCommiter, updateToken),
+          env: getPatcherEnvVars(gitCommiter, readToken, updateToken),
         }
       );
       core.endGroup();
@@ -329,7 +332,7 @@ async function runPatcher(
         "patcher",
         updateArgs(specFile, updateStrategy, prBranch, prTitle, dependency, workingDir, dryRun, noColor),
         {
-          env: getPatcherEnvVars(gitCommiter, updateToken),
+          env: getPatcherEnvVars(gitCommiter, readToken, updateToken),
         }
       );
       core.endGroup();
@@ -380,6 +383,7 @@ async function validateAccessToPatcherCli(octokit: GitHub) {
 
 export async function run() {
   const gruntworkToken = core.getInput("github_token");
+  const patcherReadToken = core.getInput("read_token");
   const patcherUpdateToken = core.getInput("update_token");
   const command = core.getInput("patcher_command");
   const updateStrategy = core.getInput("update_strategy");
@@ -397,10 +401,12 @@ export async function run() {
   // if the user didn't specify a token specifically for `patcher update`,
   // that's ok, we can try to use the github token instead. doing this adoption
   // is for back compatibility reasons
+  const readToken = patcherReadToken ? patcherReadToken : gruntworkToken;
   const updateToken = patcherUpdateToken ? patcherUpdateToken : gruntworkToken;
 
   // Always mask the token strings in the logs.
   core.setSecret(gruntworkToken);
+  core.setSecret(readToken);
   core.setSecret(updateToken);
 
   // Only run the action if the user has access to Patcher. Otherwise, the download won't work.
@@ -429,6 +435,7 @@ export async function run() {
     prTitle,
     dependency,
     workingDir,
+    readToken,
     updateToken,
     dryRun,
     noColor,


### PR DESCRIPTION
## description

- upgrade to patcher `v.0.10.0`
- includes support for `GITHUB_READ_TOKEN`, separately from `GITHUB_OAUTH_TOKEN`, which is used for reading upstream dependencies and their updates to determine which patcher upgrades are necessary. this token's usage is split apart from the update token, which is used to publish PRs against the client repo