### PR TITLE
replacing expired secret

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,7 +50,7 @@ jobs:
         id: run-report
         uses: ./
         with:
-          github_token: ${{ secrets.CI_READONLY_READ_TOKEN }}
+          github_token: ${{ secrets.PATCHER_FULL_REPO }}
           patcher_command: report
           working_dir: infrastructure-live
           spec_file: spec.json
@@ -79,7 +79,7 @@ jobs:
         id: run-update
         uses: ./
         with:
-          github_token: ${{ secrets.CI_READONLY_READ_TOKEN }}
+          github_token: ${{ secrets.PATCHER_FULL_REPO }}
           patcher_command: update
           working_dir: infrastructure-live
           spec_file: spec.json


### PR DESCRIPTION
we've been seeing secrets errors on the CI workflow:

<img width="649" alt="Screenshot 2024-12-03 at 1 14 27 PM" src="https://github.com/user-attachments/assets/15caa36b-fa09-4684-982b-f59a0a9ebaf5">

this PR adds in a new secret (the old one expired 4 months ago, and since 3 months is a valid PAT expiration timeline in github, this makes sense)