### PR TITLE
Force customer token for module cloning

### DIFF
--- a/.github/workflows/patcher.yml
+++ b/.github/workflows/patcher.yml
@@ -47,7 +47,7 @@ on:
       pull_request_branch:
         description: "Branch for Pull Requests. Defaults to 'patcher-updates' (or 'patcher-updates-<dependency-ID>' when dependency is set)."
         type: string
-        default: ""
+        default: "patcher-updates"
       pull_request_title:
         description: "Title of the Pull Request."
         type: string
@@ -96,6 +96,10 @@ on:
         description: "Ref (tag or branch) for pipelines-actions."
         type: string
         default: "v4.3.0"
+      use_customer_token_for_modules:
+        description: "forces use of customer org token for modules"
+        type: string
+        default: false
     outputs:
       spec:
         description: "Upgrade specification JSON produced by patcher report."
@@ -195,7 +199,7 @@ jobs:
       - name: Run patcher report
         id: run-report
         env:
-          GITHUB_OAUTH_TOKEN: ${{ inputs.pipelines_actions_repo == 'gruntwork-io/pipelines-actions' && steps.gruntwork-read-token.outputs.PIPELINES_TOKEN || steps.org-read-token.outputs.PIPELINES_TOKEN }}
+          GITHUB_OAUTH_TOKEN: ${{ inputs.use_customer_token_for_modules == false && steps.gruntwork-read-token.outputs.PIPELINES_TOKEN || steps.org-read-token.outputs.PIPELINES_TOKEN }}
           GIT_AUTHOR_NAME: ${{ inputs.commit_author_name }}
           GIT_AUTHOR_EMAIL: ${{ inputs.commit_author_email }}
           PATCHER_TELEMETRY_ID: "GHAction-${{ github.repository }}"
@@ -257,7 +261,7 @@ jobs:
       - name: Run patcher update
         if: ${{ inputs.skip_update == false && steps.run-report.outputs.has_dependencies == 'true' }}
         env:
-          GITHUB_OAUTH_TOKEN: ${{ inputs.pipelines_actions_repo == 'gruntwork-io/pipelines-actions' && steps.gruntwork-read-token.outputs.PIPELINES_TOKEN || steps.org-read-token.outputs.PIPELINES_TOKEN }}
+          GITHUB_OAUTH_TOKEN: ${{ inputs.use_customer_token_for_modules == false && steps.gruntwork-read-token.outputs.PIPELINES_TOKEN || steps.org-read-token.outputs.PIPELINES_TOKEN }}
           GITHUB_PUBLISH_TOKEN: ${{ steps.pr-create-token.outputs.PIPELINES_TOKEN }}
           GIT_AUTHOR_NAME: ${{ inputs.commit_author_name }}
           GIT_AUTHOR_EMAIL: ${{ inputs.commit_author_email }}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added an option to control which token is used for module-related patcher actions.
  * Set a clearer default branch name for patcher-generated pull request updates when none is provided.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->